### PR TITLE
remove node 8 in travis as we don't really support it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@
 
 language: node_js
 node_js:
-  - 8
   - 10
   - 12
   - 13


### PR DESCRIPTION
...and it keeps failing fsevents tests