### PR TITLE
fix node_modules exclusion glob that made tests fail on Linux sometimes

### DIFF
--- a/src/watcher.js
+++ b/src/watcher.js
@@ -40,7 +40,7 @@ class Watcher {
             this.liveReloadServer = livereload.createServer({
                 port: this.argv.livereloadPort,
                 noListen: !this.argv.livereload,
-                exclusions: [this.argv.buildPath, "node_modules/**"],
+                exclusions: [this.argv.buildPath, "**/node_modules/**", "**/.*"],
                 exts: this.argv.watchExts || ["json", "js", "ts", "coffee", "py", "rb", "erb", "go", "java", "scala", "php", "swift", "rs", "cs", "bal", "php", "php5"],
                 extraExts: []
             });


### PR DESCRIPTION
Fixes #34.

`livereload/chokidar` was watching all files in the node_modules folder for the test:
`should invoke action when a source file changes and -P is set when source-path points to directory`

Problem was an incorrect glob.

Also excluding any hidden paths - files or dirs starting with a dot.