### PR TITLE
allow scancode.sh to be run repeatedly and locally

### DIFF
--- a/travis/scancode.sh
+++ b/travis/scancode.sh
@@ -26,7 +26,13 @@ UTIL_DIR="$HOMEDIR/openwhisk-utilities"
 
 # clone OpenWhisk utilities repo. in order to run scanCode.py
 cd $HOMEDIR
-git clone https://github.com/apache/openwhisk-utilities.git
+
+if [ ! -d "openwhisk-utilities" ] ; then
+    git clone https://github.com/apache/openwhisk-utilities.git
+else
+    cd "openwhisk-utilities"
+    git pull
+fi
 
 # run scancode
 cd $UTIL_DIR


### PR DESCRIPTION
Before it failed if you ran it again since `git clone` will complain about the `openwhisk-utilities` directory already being present.

With this I added it to a pre-commit hook:

In `.git/hooks/pre-commit`:

```
#!/bin/sh

./travis/scancode.sh 
```