### PR TITLE
validate source path etc. before async installation of agent

### DIFF
--- a/src/agentmgr.js
+++ b/src/agentmgr.js
@@ -264,6 +264,8 @@ class AgentMgr {
     }
 
     async shutdown() {
+        this.shuttingDown = true;
+
         try {
             // make sure we finished creating the backup
             await this.createBackup;
@@ -528,6 +530,11 @@ class AgentMgr {
 
         // this is to support older openwhisks for which nodejs:default is less than version 8
         const nodejs8 = await this.openwhiskSupports("nodejs8");
+
+        if (this.shuttingDown) {
+            // race condition on shutdown during startup due to errors
+            return;
+        }
 
         await this.wsk.actions.update({
             name: this.actionName,

--- a/src/debugger.js
+++ b/src/debugger.js
@@ -71,16 +71,18 @@ class Debugger {
         this.invoker = new OpenWhiskInvoker(this.actionName, actionMetadata, this.argv, this.wskProps, this.wsk);
 
         try {
+            // run build initially (would be required by starting container)
+            if (this.argv.onBuild) {
+                console.info("=> Build:", this.argv.onBuild);
+                spawnSync(this.argv.onBuild, {shell: true, stdio: "inherit"});
+            }
+            await this.invoker.prepare();
+
             // parallelize slower work using promises
 
             // task 1 - start local container
             const containerTask = (async () => {
                 const debugTask = debug.task();
-                // run build initially (would be required by starting container)
-                if (this.argv.onBuild) {
-                    console.info("=> Build:", this.argv.onBuild);
-                    spawnSync(this.argv.onBuild, {shell: true, stdio: "inherit"});
-                }
 
                 // start container - get it up fast for VSCode to connect within its 10 seconds timeout
                 await this.invoker.startContainer();

--- a/src/kinds/nodejs/nodejs.js
+++ b/src/kinds/nodejs/nodejs.js
@@ -39,7 +39,7 @@ module.exports = {
         let args = "";
         if (invoker.sourceDir) {
             if (!invoker.sourceFile) {
-                throw new Error("[source-path] or --build-path must point to the action javascript source file, it cannot be a folder.");
+                throw new Error(`[source-path] or --build-path must point to a source file, it cannot be a folder: '${invoker.sourcePath}'`);
             }
 
             args += ` -v "${invoker.sourceDir}:${CODE_MOUNT}"`;
@@ -58,6 +58,10 @@ module.exports = {
     // return action for /init that mounts the sources specified by invoker.sourcePath
     mountAction: function(invoker) {
         // bridge that mounts local source path
+
+        if (fs.statSync(invoker.sourcePath).isDirectory()) {
+            throw new Error(`[source-path] or --build-path must point to a source file, it cannot be a folder: '${invoker.sourcePath}'`);
+        }
 
         // test if code uses commonjs require()
         const isCommonJS = /(\s|=)require\(\s*['"`]/.test(fs.readFileSync(invoker.sourcePath));


### PR DESCRIPTION
Fixes regression from #45.

- separate OpenWhiskInvoker.prepare() phase for validation
- better error msg if sourcePath points to folder
- fix race condition on early error related shutdown