### PR TITLE
wskdebug does not work with new vs code debugger

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,16 @@ The action to debug (e.g. `myaction`) must already be deployed.
 <a name="nodejs-visual-studio-code"></a>
 ### Node.js: Visual Studio Code
 
+> ⚠️ **VS Code June 2020 release (version 1.47) breaks wskdebug**
+>
+> Breakpoints will not hit because it debugs the wskdebug process instead of the action.
+>
+> Workaround: set `"debug.javascript.usePreview": false` in your VS Code `settings.json`.
+>
+> A better solution will come with a new VS Code update and wskdebug 1.3.0.
+>
+> More details in [issue #74](https://github.com/apache/openwhisk-wskdebug/issues/74).
+
 Add the configuration below to your [launch.json](https://code.visualstudio.com/docs/editor/debugging#_launch-configurations). Replace `MYACTION` with the name of your action and `ACTION.js` with the source file containing the action. When you run this, it will start wskdebug and should automatically connect the debugger.
 
 ```json
@@ -524,6 +534,22 @@ Options:
 
 <a name="troubleshooting"></a>
 ## Troubleshooting
+
+### Debugger in VS Code does not hit breakpoints
+
+If you use VS Code June 2020 release (version 1.47) it breaks wskdebug due to the new Javascript debugger implementation it includes. Breakpoints will not hit because it debugs the wskdebug process instead of the action.
+
+#### Workaround
+
+Tell VS Code to use the old debugger. In your VS Code `settings.json` set:
+
+```
+"debug.javascript.usePreview": false
+```
+
+A better solution will come with a new VS Code update and wskdebug 1.3.0.
+
+More details in [issue #74](https://github.com/apache/openwhisk-wskdebug/issues/74).
 
 ### Cannot install  - EACCES: permission denied, access '/usr/local/lib/node_modules
 

--- a/src/debugger.js
+++ b/src/debugger.js
@@ -27,6 +27,7 @@ const sleep = require('util').promisify(setTimeout);
 const prettyBytes = require('pretty-bytes');
 const prettyMilliseconds = require('pretty-ms');
 const log = require('./log');
+const inspector = require('inspector');
 
 function prettyMBytes1024(mb) {
     if (mb > 1024) {
@@ -49,6 +50,21 @@ class Debugger {
     constructor(argv) {
         this.startTime = Date.now();
         log.debug("starting debugger");
+
+        // see if our process is debugged, which might not be desired
+        if (inspector.url()) {
+            log.warn(`
++------------------------------------------------------------------------------------------+
+| WARNING: wskdebug itself is debugged and likely NOT the action                           |
+|                                                                                          |
+| This could be an issue with the debug setup. Notably, VS Code changed their debugger     |
+| implementation in June/July 2020 requiring changes to launch.json. For more see:         |
+|                                                                                          |
+|     https://github.com/apache/openwhisk-wskdebug/issues/74                               |
+|                                                                                          |
++------------------------------------------------------------------------------------------+
+            `);
+        }
 
         this.argv = argv;
         this.actionName = argv.action;


### PR DESCRIPTION
Addresses #74 through documentation and hints.

- detect problematic case and print big warning and help
- document in readme