### PR TITLE
use lts node, instead of latest

### DIFF
--- a/test/install/Dockerfile
+++ b/test/install/Dockerfile
@@ -16,7 +16,7 @@
 #
 
 # docker build for testing wskdebug installation
-FROM circleci/node
+FROM circleci/node:lts
 LABEL type=test
 
 WORKDIR /home/circleci


### PR DESCRIPTION
As suggested in #80, use circleci/node:lts instead of :latest

