### PR TITLE
fix: nodejs mounted action runner should set the right current working directory

### DIFF
--- a/src/kinds/nodejs/mount-plain.js
+++ b/src/kinds/nodejs/mount-plain.js
@@ -18,6 +18,7 @@
 /* eslint-disable strict */
 
 const fs = require('fs');
+const nodePath = require('path');
 
 // Variables will be replaced before the code is loaded
 
@@ -43,6 +44,8 @@ function load(path) {
 
 // eslint-disable-next-line no-unused-vars
 function main(args) { // lgtm [js/unused-local-variable]
+    process.chdir(nodePath.dirname(path));
+
     // load code again on every new invocation
     const actionMain = load(path);
 

--- a/src/kinds/nodejs/mount-require.js
+++ b/src/kinds/nodejs/mount-require.js
@@ -17,6 +17,8 @@
 
 /* eslint-disable strict */
 
+const nodePath = require('path');
+
 // Variables will be replaced before the code is loaded
 
 // path to actual action sources
@@ -36,6 +38,7 @@ let firstRun = true;
 
 // eslint-disable-next-line no-unused-vars
 function main(args) { // lgtm [js/unused-local-variable]
+    process.chdir(nodePath.dirname(path));
 
     if (firstRun) {
         const start = Date.now();


### PR DESCRIPTION
Closes #79

Tested manually via action file in https://github.com/adobe/aio-cli-plugin-app/issues/282 and including a text file with the action (via the manifest.yml)

Debugged the action remotely and locally, and the current working directory listing includes the file that was included in the action.

`npm test` shows no errors.