### PR TITLE
java example: change java version from unsupported version to 1.8

### DIFF
--- a/examples/java/pom.xml
+++ b/examples/java/pom.xml
@@ -11,6 +11,11 @@
 	<!-- Output to jar format -->
 	<packaging>jar</packaging>
 
+    <properties>
+         <maven.compiler.source>1.8</maven.compiler.source>
+         <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
 	<dependencies>
         <dependency>
           <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
Compiling the Java example in `examples/java` with `mvn clean package` was failing with:

```
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] Source option 5 is no longer supported. Use 6 or later.
[ERROR] Target option 1.5 is no longer supported. Use 1.6 or later.
```

Fixed it by setting it to 1.8 in the pom.

Noticed while reviewing #109 . The example is simple and the java version doesn't really matter here.