### PR TITLE
github PRs: require branches to be up to date before merging

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -33,7 +33,7 @@ github:
   protected_branches:
     master:
       required_status_checks:
-        strict: false
+        strict: true
         contexts:
           - "Travis CI - Pull Request"
       required_pull_request_reviews:


### PR DESCRIPTION
Came up in #85. We want to make sure PRs are tested with the latest master state.

According to [this documentation](https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features) setting `strict: true` in the `.asf.yaml` should do the trick.