### PR TITLE
github PRs: automatically delete branches after merging

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -43,6 +43,7 @@ github:
     merge: false
     squash: true
     rebase: true
+  del_branch_on_merge: true
   features:
     issues: true
 


### PR DESCRIPTION
Following #111, more `.asf.yaml` to get the useful github feature of deleting the branches automatically once PRs are merged, to keep things clean.